### PR TITLE
Update parsecss.class.php

### DIFF
--- a/parsecss.class.php
+++ b/parsecss.class.php
@@ -93,7 +93,7 @@ class CSS
 		foreach($this->css as $key0 => $value0) {
 			$trimmed = trim($key0);
 			$this->cssstr .= "$trimmed {\n";
-			if($sorted) ksort(&$this->css[$key0], SORT_STRING);
+			if($sorted) ksort($this->css[$key0], SORT_STRING);
 			foreach($this->css[$key0] as $key1 => $value1) {
 				$this->cssstr .= "\t$key1: $value1;\n";
 			}


### PR DESCRIPTION
I got this error "Call-time pass-by-reference has been removed". I updated the class for PHP 5.5.12
